### PR TITLE
Change CMake boost link

### DIFF
--- a/lib/util/CMakeLists.txt
+++ b/lib/util/CMakeLists.txt
@@ -36,6 +36,10 @@ set(headers
   BVutil.h
   )
 
+set(Boost_USE_MULTITHREADED ON) 
+
+find_package(Boost REQUIRED COMPONENTS thread system)
+include_directories(${Boost_INCLUDE_DIRS})
 include_directories(${LIBXML2_INCLUDE_DIR})
 include_directories(${SDL_INCLUDE_DIR})
 include_directories(${OpenCV_INCLUDE_DIRS})
@@ -52,9 +56,8 @@ target_link_libraries(hrpsysUtil
   ${SDL_LIBRARY} 
   ${GLUT_LIBRARIES} 
   ${QHULL_LIBRARIES}
+  ${Boost_LIBRARIES}
   GLEW
-  boost_thread-mt
-  boost_system-mt
   )
 
 set(target hrpsysUtil)


### PR DESCRIPTION
Hi Kakiuchi-san :)
I'm preparing for the Google Summer of Code and according to Kei's suggestion, I'm testing out the fcl module from your repo.
It cannot be built on my computer with Ubuntu 14.04 Boost 1.54 since currently boost has removed the -mt suffix and support multi-thread in its original modules and enable the multi-thread option is good enough.
I updated the CMakeList to fit for major systems currently.